### PR TITLE
Fix compilation with libstdc++

### DIFF
--- a/src/MeshPlaneIntersect.hpp
+++ b/src/MeshPlaneIntersect.hpp
@@ -145,7 +145,7 @@ public:
 		}
 
 		static EdgePath GetEdgePath(CrossingFaceMap& crossingFaces) {
-			auto currentFace = crossingFaces.begin();
+			auto currentFace = crossingFaces.cbegin();
 			EdgePath edgePath({ currentFace->first });
 			int closingVertex(currentFace->second);
 			while (GetNextPoint(currentFace, crossingFaces)) {


### PR DESCRIPTION
In GNU C++ STL, std::map::iterator doesn't coerce to `std::map::const_iterator`. Hence we should explicitly use `.cbegin()` to get a `const_iterator`.